### PR TITLE
Add 1Password (op) provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,10 @@ Use `provider: op` to fetch secrets from [1Password](https://1password.com/) usi
 ### Prerequisites
 
 - The [1Password CLI](https://developer.1password.com/docs/cli/get-started/) (`op`) installed on your Buildkite agent
-- A [1Password Service Account](https://developer.1password.com/docs/service-accounts/) with read access to the relevant vaults. Set the `OP_SERVICE_ACCOUNT_TOKEN` environment variable on the agent (recommended for CI), or authenticate interactively with `op signin`.
+- One of the following authentication methods configured on the agent:
+  - **Connect Server** (recommended for self-hosted agents): set `OP_CONNECT_HOST` and `OP_CONNECT_TOKEN`
+  - **Service Account**: set `OP_SERVICE_ACCOUNT_TOKEN`
+  - **Interactive session**: sign in with `op signin` before the build runs
 
 ### Secret References
 
@@ -404,7 +407,7 @@ These options only apply when `provider: azure` is set.
 
 ### 1Password Provider Options
 
-The `op` provider has no additional plugin options. Authentication is handled via the `OP_SERVICE_ACCOUNT_TOKEN` environment variable on the agent, or an existing `op` session. All secret paths are specified directly as `op://vault/item/field` references in `env` and `variables`.
+The `op` provider has no additional plugin options. Authentication is handled via agent environment variables (`OP_CONNECT_HOST`+`OP_CONNECT_TOKEN` for Connect Server, or `OP_SERVICE_ACCOUNT_TOKEN` for service accounts) or an existing `op` session. All secret paths are specified directly as `op://vault/item/field` references in `env` and `variables`.
 
 ## Secret Redaction
 

--- a/README.md
+++ b/README.md
@@ -234,15 +234,19 @@ Use `provider: op` to fetch secrets from [1Password](https://1password.com/) usi
 
 ### Secret References
 
-All secret values must be specified as `op://` references in the format `op://vault/item/field`:
+Secrets can be specified in either short or full form:
 
+- **Short form**: `vault/item/field` — the `op://` prefix is added automatically
+- **Full form**: `op://vault/item/field` — explicit, useful when mixing with other tooling
+
+Where:
 - `vault` — the name or ID of your 1Password vault
 - `item` — the name or ID of the item within that vault
 - `field` — the field to read from the item (e.g. `password`, `credential`, or a custom field label)
 
 ### Individual Variables
 
-Map environment variable names to `op://` secret references:
+Map environment variable names to secret references:
 
 ```yaml
 steps:
@@ -251,8 +255,8 @@ steps:
       - secrets#v2.1.0:
           provider: op
           variables:
-            API_KEY: op://my-vault/my-api-key/credential
-            DB_PASSWORD: op://my-vault/db-creds/password
+            API_KEY: my-vault/my-api-key/credential
+            DB_PASSWORD: my-vault/db-creds/password
 ```
 
 ### Batch Secrets (Base64)
@@ -280,7 +284,7 @@ steps:
     plugins:
       - secrets#v2.1.0:
           provider: op
-          env: op://my-vault/ci-batch-secrets/credential
+          env: my-vault/ci-batch-secrets/credential
 ```
 
 ## Combining Both Methods
@@ -329,9 +333,9 @@ steps:
     plugins:
       - secrets#v2.1.0:
           provider: op
-          env: op://my-vault/ci-batch-secrets/credential
+          env: my-vault/ci-batch-secrets/credential
           variables:
-            DEPLOY_KEY: op://my-vault/deploy-key/credential
+            DEPLOY_KEY: my-vault/deploy-key/credential
 ```
 
 ## Pinning a Secret Version (GCP)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Supported providers:
 - [Buildkite Secrets](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets) (default)
 - [GCP Secret Manager](https://cloud.google.com/secret-manager)
 - [Azure Key Vault](https://azure.microsoft.com/en-us/products/key-vault)
+- [1Password](https://1password.com/)
 
 ## Changes to consider when upgrading to `v2.0.0`
 
@@ -219,6 +220,66 @@ EOF
 az keyvault secret set --vault-name my-vault --name batch-secrets --value "$(base64 < data.txt)"
 ```
 
+## 1Password Provider
+
+Use `provider: op` to fetch secrets from [1Password](https://1password.com/) using the `op` CLI.
+
+### Prerequisites
+
+- The [1Password CLI](https://developer.1password.com/docs/cli/get-started/) (`op`) installed on your Buildkite agent
+- A [1Password Service Account](https://developer.1password.com/docs/service-accounts/) with read access to the relevant vaults. Set the `OP_SERVICE_ACCOUNT_TOKEN` environment variable on the agent (recommended for CI), or authenticate interactively with `op signin`.
+
+### Secret References
+
+All secret values must be specified as `op://` references in the format `op://vault/item/field`:
+
+- `vault` — the name or ID of your 1Password vault
+- `item` — the name or ID of the item within that vault
+- `field` — the field to read from the item (e.g. `password`, `credential`, or a custom field label)
+
+### Individual Variables
+
+Map environment variable names to `op://` secret references:
+
+```yaml
+steps:
+  - command: build.sh
+    plugins:
+      - secrets#v2.1.0:
+          provider: op
+          variables:
+            API_KEY: op://my-vault/my-api-key/credential
+            DB_PASSWORD: op://my-vault/db-creds/password
+```
+
+### Batch Secrets (Base64)
+
+Store multiple `KEY=value` pairs in a single 1Password item field, base64-encoded, and use `env` to fetch and decode them all at once:
+
+```shell
+# Create a file with KEY=value pairs
+cat > data.txt <<EOF
+DB_HOST=mydb.example.com
+DB_PASSWORD=supersecret
+API_KEY=abc123
+EOF
+
+# Base64 encode and store as a 1Password item (e.g. in a "Password" or "Text" field)
+op item create --category=login --title="ci-batch-secrets" --vault=my-vault \
+  credential="$(base64 < data.txt)"
+```
+
+Then reference it in your pipeline:
+
+```yaml
+steps:
+  - command: build.sh
+    plugins:
+      - secrets#v2.1.0:
+          provider: op
+          env: op://my-vault/ci-batch-secrets/credential
+```
+
 ## Combining Both Methods
 
 You can use `env` and `variables` together to fetch both batch and individual secrets in a single plugin call.
@@ -255,6 +316,19 @@ steps:
           env: batch-secrets
           variables:
             DEPLOY_KEY: deploy-key-secret
+```
+
+**1Password:**
+
+```yaml
+steps:
+  - command: build.sh
+    plugins:
+      - secrets#v2.1.0:
+          provider: op
+          env: op://my-vault/ci-batch-secrets/credential
+          variables:
+            DEPLOY_KEY: op://my-vault/deploy-key/credential
 ```
 
 ## Pinning a Secret Version (GCP)
@@ -303,7 +377,7 @@ These options apply to all providers.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `provider` | string | `buildkite` | The secrets provider to use. Supported values: `buildkite`, `gcp`, `azure`. |
+| `provider` | string | `buildkite` | The secrets provider to use. Supported values: `buildkite`, `gcp`, `azure`, `op`. |
 | `env` | string | - | Secret key name for fetching batch secrets (base64-encoded `KEY=value` format). |
 | `variables` | object | - | Map of `ENV_VAR_NAME: secret-path` pairs to inject as environment variables. |
 | `skip-redaction` | boolean | `false` | If `true`, secrets will not be automatically redacted from logs. |
@@ -327,6 +401,10 @@ These options only apply when `provider: azure` is set.
 |--------|------|---------|-------------|
 | `azure-vault-name` | string | - | The Azure Key Vault name (required when provider is azure). |
 | `azure-secret-version` | string | latest | The secret version to fetch. If not specified, the latest version is used. |
+
+### 1Password Provider Options
+
+The `op` provider has no additional plugin options. Authentication is handled via the `OP_SERVICE_ACCOUNT_TOKEN` environment variable on the agent, or an existing `op` session. All secret paths are specified directly as `op://vault/item/field` references in `env` and `variables`.
 
 ## Secret Redaction
 

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -61,6 +61,9 @@ setup_provider_environment() {
     azure)
       setup_azure_environment
       ;;
+    op)
+      setup_op_environment
+      ;;
     *)
       unknown_provider "${BUILDKITE_PLUGIN_SECRETS_PROVIDER}"
       ;;
@@ -77,6 +80,9 @@ fetch_secrets() {
       ;;
     azure)
       fetch_azure_secrets
+      ;;
+    op)
+      fetch_op_secrets
       ;;
     *)
       unknown_provider "${BUILDKITE_PLUGIN_SECRETS_PROVIDER}"

--- a/lib/providers/op.bash
+++ b/lib/providers/op.bash
@@ -74,9 +74,14 @@ op_secret_get_with_retry() {
 download_op_secret() {
   local secret_ref="$1"
 
-  # Validate that the value looks like an op:// secret reference
+  # Prepend op:// if not already present, allowing short-form vault/item/field references
+  if [[ "$secret_ref" != op://* ]]; then
+    secret_ref="op://${secret_ref}"
+  fi
+
+  # Validate op:// secret reference has at least vault/item/field components
   if [[ ! "$secret_ref" =~ ^op://[^/]+/[^/]+/[^/]+ ]]; then
-    log_error "Invalid 1Password secret reference: '${secret_ref}' (must be in op://vault/item/field format)"
+    log_error "Invalid 1Password secret reference: '${1}' (must be vault/item/field or op://vault/item/field)"
     return 1
   fi
 

--- a/lib/providers/op.bash
+++ b/lib/providers/op.bash
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+setup_op_environment() {
+  check_dependencies
+
+  # Warn if no service account token is set and no active session exists
+  if [[ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
+    if ! op account list --format=json >/dev/null 2>&1; then
+      log_error "No 1Password service account token found (OP_SERVICE_ACCOUNT_TOKEN) and no active op session"
+      log_info "Set OP_SERVICE_ACCOUNT_TOKEN or sign in with 'op signin' before running this plugin"
+      exit 1
+    fi
+  fi
+}
+
+op_secret_get_with_retry() {
+  local SECRET_REF="$1"
+  local MAX_ATTEMPTS="${BUILDKITE_PLUGIN_SECRETS_RETRY_MAX_ATTEMPTS:-5}"
+  local BASE_DELAY="${BUILDKITE_PLUGIN_SECRETS_RETRY_BASE_DELAY:-2}"
+  local ATTEMPT=1
+  local EXIT_CODE
+  local OUTPUT
+
+  while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
+    local STDERR_TMP
+    STDERR_TMP=$(mktemp)
+    trap 'rm -f "$STDERR_TMP"' RETURN
+
+    set +e
+    OUTPUT=$(op read "${SECRET_REF}" 2>"$STDERR_TMP")
+    EXIT_CODE=$?
+    set -e
+
+    local STDERR_OUTPUT
+    STDERR_OUTPUT=$(cat "$STDERR_TMP")
+    rm -f "$STDERR_TMP"
+
+    if [ "$EXIT_CODE" -eq 0 ]; then
+      echo "$OUTPUT"
+      return 0
+    fi
+
+    # Non-retryable: item/vault not found, auth errors, invalid reference
+    if echo "$STDERR_OUTPUT" | grep -qiE "isn't an item in|isn't a vault|not found|unauthorized|forbidden|invalid secret reference|authentication required"; then
+      echo "$STDERR_OUTPUT" >&2
+      return "$EXIT_CODE"
+    fi
+
+    if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then
+      local TOTAL_DELAY
+      TOTAL_DELAY=$(calculate_backoff_delay "$BASE_DELAY" "$ATTEMPT")
+
+      log_info "Failed to fetch secret ${SECRET_REF} (attempt ${ATTEMPT}/${MAX_ATTEMPTS}). Retrying in ${TOTAL_DELAY}s..."
+      echo "Error: $STDERR_OUTPUT" >&2
+
+      sleep "$TOTAL_DELAY"
+      ATTEMPT=$((ATTEMPT + 1))
+    else
+      log_error "Failed to fetch secret ${SECRET_REF} after ${MAX_ATTEMPTS} attempts"
+      echo "Error: $STDERR_OUTPUT" >&2
+      return "$EXIT_CODE"
+    fi
+  done
+}
+
+download_op_secret() {
+  local secret_ref="$1"
+
+  # Validate that the value looks like an op:// secret reference
+  if [[ ! "$secret_ref" =~ ^op://[^/]+/[^/]+/[^/]+ ]]; then
+    log_error "Invalid 1Password secret reference: '${secret_ref}' (must be in op://vault/item/field format)"
+    return 1
+  fi
+
+  local output
+  if output=$(op_secret_get_with_retry "${secret_ref}"); then
+    echo "${output}"
+  else
+    log_error "Failed to fetch 1Password secret: ${secret_ref}"
+    return 1
+  fi
+}
+
+process_op_secrets() {
+  local encoded_secret="$1"
+  local key_name="$2"
+  local decoded_secret
+  local key value
+
+  local decode_status=0
+  decoded_secret=$(echo "$encoded_secret" | base64 -d 2>/dev/null) || decode_status=$?
+
+  if [[ $decode_status -ne 0 ]] || [[ -z "$decoded_secret" ]]; then
+    log_error "Failed to decode base64 secret for key: ${key_name}"
+    log_error "The secret may be malformed or not properly base64-encoded"
+    return 1
+  fi
+
+  if [[ "$decoded_secret" =~ ^[[:space:]]+$ ]]; then
+    log_error "Decoded secret for key: ${key_name} is empty or contains only whitespace"
+    return 1
+  fi
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+
+    if [[ "$line" != *"="* ]]; then
+      log_warning "Skipping malformed line in secret '${key_name}': missing '=' separator"
+      continue
+    fi
+
+    key="${line%%=*}"
+    value="${line#*=}"
+
+    if [[ -n "$key" ]]; then
+      if [[ ! "$key" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        log_warning "Skipping invalid variable name '${key}' in secret '${key_name}' (must start with letter or underscore)"
+        continue
+      fi
+
+      OP_SECRETS_TO_REDACT+=("$value")
+      export "$key=$value"
+    fi
+  done <<< "$decoded_secret"
+}
+
+process_op_variables() {
+  local key path value
+  for param in ${!BUILDKITE_PLUGIN_SECRETS_VARIABLES_*}; do
+    key="${param/BUILDKITE_PLUGIN_SECRETS_VARIABLES_/}"
+    path="${!param}"
+
+    if [[ ! "$key" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+      log_warning "Skipping invalid variable name '${key}'"
+      continue
+    fi
+
+    if ! value=$(download_op_secret "${path}"); then
+      log_error "Unable to find secret at ${path}"
+      exit 1
+    else
+      OP_SECRETS_TO_REDACT+=("$value")
+      export "$key=$value"
+    fi
+  done
+}
+
+fetch_op_secrets() {
+  local OP_SECRETS_TO_REDACT=()
+  local secret
+
+  # Disable debug tracing to prevent secret leaks
+  local xtrace_was_set=0
+  [[ -o xtrace ]] && xtrace_was_set=1
+  { set +x; } 2>/dev/null
+
+  log_info "Fetching 1Password secrets"
+
+  if [[ -n "${BUILDKITE_PLUGIN_SECRETS_ENV+x}" ]]; then
+    if secret=$(download_op_secret "${BUILDKITE_PLUGIN_SECRETS_ENV}"); then
+      process_op_secrets "${secret}" "${BUILDKITE_PLUGIN_SECRETS_ENV}"
+    else
+      log_error "No secret found at ${BUILDKITE_PLUGIN_SECRETS_ENV}"
+      if [[ $xtrace_was_set -eq 1 ]]; then set -x; else { set +x; } 2>/dev/null; fi
+      return 1
+    fi
+  fi
+
+  process_op_variables
+
+  if [[ "${BUILDKITE_PLUGIN_SECRETS_SKIP_REDACTION:-}" != "true" ]] && [[ ${#OP_SECRETS_TO_REDACT[@]} -gt 0 ]]; then
+    redact_secrets OP_SECRETS_TO_REDACT
+  fi
+
+  if [[ $xtrace_was_set -eq 1 ]]; then set -x; else { set +x; } 2>/dev/null; fi
+}

--- a/lib/providers/op.bash
+++ b/lib/providers/op.bash
@@ -29,28 +29,27 @@ op_secret_get_with_retry() {
   local ATTEMPT=1
   local EXIT_CODE
   local OUTPUT
+  local STDERR_TMP
+  local STDERR_OUTPUT
+  STDERR_TMP=$(mktemp)
+  trap 'rm -f "$STDERR_TMP"' RETURN
 
   while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
-    local STDERR_TMP
-    STDERR_TMP=$(mktemp)
-    trap 'rm -f "$STDERR_TMP"' RETURN
-
     set +e
     OUTPUT=$(op read "${SECRET_REF}" 2>"$STDERR_TMP")
     EXIT_CODE=$?
     set -e
 
-    local STDERR_OUTPUT
     STDERR_OUTPUT=$(cat "$STDERR_TMP")
-    rm -f "$STDERR_TMP"
+    : > "$STDERR_TMP"
 
     if [ "$EXIT_CODE" -eq 0 ]; then
       echo "$OUTPUT"
       return 0
     fi
 
-    # Non-retryable: item/vault not found, auth errors, invalid reference
-    if echo "$STDERR_OUTPUT" | grep -qiE "isn't an item in|isn't a vault|not found|unauthorized|forbidden|invalid secret reference|authentication required"; then
+    # Non-retryable: item/vault not found, auth errors, invalid reference format
+    if echo "$STDERR_OUTPUT" | grep -qiE "isn't an item in|isn't a vault|unauthorized|forbidden|invalid secret reference|authentication required"; then
       echo "$STDERR_OUTPUT" >&2
       return "$EXIT_CODE"
     fi

--- a/lib/providers/op.bash
+++ b/lib/providers/op.bash
@@ -3,13 +3,22 @@
 setup_op_environment() {
   check_dependencies
 
-  # Warn if no service account token is set and no active session exists
-  if [[ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
-    if ! op account list --format=json >/dev/null 2>&1; then
-      log_error "No 1Password service account token found (OP_SERVICE_ACCOUNT_TOKEN) and no active op session"
-      log_info "Set OP_SERVICE_ACCOUNT_TOKEN or sign in with 'op signin' before running this plugin"
-      exit 1
-    fi
+  # Accept any of the three supported auth methods:
+  #   1. Connect Server  (OP_CONNECT_HOST + OP_CONNECT_TOKEN)
+  #   2. Service account (OP_SERVICE_ACCOUNT_TOKEN)
+  #   3. Interactive session (op signin)
+  if [[ -n "${OP_CONNECT_HOST:-}" ]] && [[ -n "${OP_CONNECT_TOKEN:-}" ]]; then
+    return 0
+  fi
+
+  if [[ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
+    return 0
+  fi
+
+  if ! op account list --format=json >/dev/null 2>&1; then
+    log_error "No 1Password authentication found"
+    log_info "Provide one of: OP_CONNECT_HOST+OP_CONNECT_TOKEN (Connect Server), OP_SERVICE_ACCOUNT_TOKEN (service account), or sign in with 'op signin'"
+    exit 1
   fi
 }
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -162,11 +162,22 @@ redact_secrets() {
        if [[ ${#secret} -ge 4 ]] && [[ "$secret" =~ ^[A-Za-z0-9+/_-]+(={0,2})?$ ]]; then
         # Try decoding with different padding scenarios (standard, +1 pad, +2 pads)
         # This handles both padded and unpadded base64 strings
+        local decode_tmp
+        decode_tmp=$(mktemp)
+
         for padding in "" "=" "=="; do
-          if decoded=$(echo "${secret}${padding}" | base64 -d 2>/dev/null) && [[ -n "$decoded" ]]; then
-            # Skip if decoded value contains non-printable/binary data
-            # This prevents false positives where random strings decode to garbage
-            if ! LC_ALL=C grep -q '[^[:print:][:space:]]' <<< "$decoded" 2>/dev/null; then
+          # Decode to a temp file so we can check for binary/null-byte content
+          # before assigning to a bash variable (bash warns and strips null bytes
+          # when command substitution output contains them)
+          if echo "${secret}${padding}" | base64 -d > "$decode_tmp" 2>/dev/null && [[ -s "$decode_tmp" ]]; then
+            # Skip if decoded value contains null bytes or other non-printable/binary data
+            if LC_ALL=C grep -qP '\x00' "$decode_tmp" 2>/dev/null || \
+               LC_ALL=C grep -q '[^[:print:][:space:]]' "$decode_tmp" 2>/dev/null; then
+              continue
+            fi
+
+            decoded=$(cat "$decode_tmp")
+            if [[ -n "$decoded" ]]; then
               # Validate with round-trip: encode the decoded value and check if it matches
               # Check both with and without trailing newline as different base64 implementations vary
               local reencoded_with_newline reencoded_without_newline
@@ -188,6 +199,8 @@ redact_secrets() {
             fi
           fi
         done
+
+        rm -f "$decode_tmp"
       fi
 
       # Only redact if we successfully validated it's real base64 and decoded value differs from original

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -162,7 +162,7 @@ redact_secrets() {
        if [[ ${#secret} -ge 4 ]] && [[ "$secret" =~ ^[A-Za-z0-9+/_-]+(={0,2})?$ ]]; then
         # Try decoding with different padding scenarios (standard, +1 pad, +2 pads)
         # This handles both padded and unpadded base64 strings
-        local decode_tmp
+        local decode_tmp raw_size clean_size
         decode_tmp=$(mktemp)
 
         for padding in "" "=" "=="; do
@@ -172,7 +172,6 @@ redact_secrets() {
           if echo "${secret}${padding}" | base64 -d > "$decode_tmp" 2>/dev/null && [[ -s "$decode_tmp" ]]; then
             # Skip if decoded value contains null bytes — use tr/wc rather than grep
             # because grep implementations vary in how they handle null bytes
-            local raw_size clean_size
             raw_size=$(wc -c < "$decode_tmp")
             clean_size=$(tr -d '\0' < "$decode_tmp" | wc -c)
             if [[ "$raw_size" != "$clean_size" ]]; then

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -170,9 +170,17 @@ redact_secrets() {
           # before assigning to a bash variable (bash warns and strips null bytes
           # when command substitution output contains them)
           if echo "${secret}${padding}" | base64 -d > "$decode_tmp" 2>/dev/null && [[ -s "$decode_tmp" ]]; then
-            # Skip if decoded value contains null bytes or other non-printable/binary data
-            if LC_ALL=C grep -qP '\x00' "$decode_tmp" 2>/dev/null || \
-               LC_ALL=C grep -q '[^[:print:][:space:]]' "$decode_tmp" 2>/dev/null; then
+            # Skip if decoded value contains null bytes — use tr/wc rather than grep
+            # because grep implementations vary in how they handle null bytes
+            local raw_size clean_size
+            raw_size=$(wc -c < "$decode_tmp")
+            clean_size=$(tr -d '\0' < "$decode_tmp" | wc -c)
+            if [[ "$raw_size" != "$clean_size" ]]; then
+              continue
+            fi
+
+            # Skip if decoded value contains other non-printable/binary data
+            if LC_ALL=C grep -q '[^[:print:][:space:]]' "$decode_tmp" 2>/dev/null; then
               continue
             fi
 

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -61,6 +61,13 @@ check_dependencies() {
         log_info "Install: https://learn.microsoft.com/en-us/cli/azure/install-azure-cli"
       fi
       ;;
+    op)
+      if ! command_exists op; then
+        missing_deps+=("op")
+        log_error "1Password CLI (op) is required for 1Password secrets"
+        log_info "Install: https://developer.1password.com/docs/cli/get-started/"
+      fi
+      ;;
     *)
       unknown_provider "${BUILDKITE_PLUGIN_SECRETS_PROVIDER}"
       ;;

--- a/plugin.yml
+++ b/plugin.yml
@@ -9,7 +9,7 @@ configuration:
   properties:
     provider:
       type: string
-      enum: ["buildkite", "gcp", "azure"]
+      enum: ["buildkite", "gcp", "azure", "op"]
       default: "buildkite"
       description: "The secrets provider to use."
     azure-vault-name:

--- a/tests/op-provider.bats
+++ b/tests/op-provider.bats
@@ -31,6 +31,7 @@ teardown() {
 @test "1Password: Fails when op CLI is missing" {
   local tmp
   tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' RETURN
 
   cat <<'EOF' >"$tmp/dirname"
 #!/bin/bash
@@ -55,12 +56,12 @@ EOF
 
 @test "1Password: Fails when no auth credentials and no active session" {
   unset OP_SERVICE_ACCOUNT_TOKEN
+  unset OP_CONNECT_HOST
+  unset OP_CONNECT_TOKEN
 
-  stub op \
-    "account list --format=json : exit 1" \
-    "* : exit 1"
+  stub op "account list --format=json : exit 1"
 
-  run bash -c "unset OP_SERVICE_ACCOUNT_TOKEN; unset OP_CONNECT_HOST; unset OP_CONNECT_TOKEN; $PWD/hooks/environment"
+  run bash -c "$PWD/hooks/environment"
 
   assert_failure
   assert_output --partial "No 1Password authentication found"

--- a/tests/op-provider.bats
+++ b/tests/op-provider.bats
@@ -1,0 +1,268 @@
+#!/usr/bin/env bats
+
+setup() {
+  load "${BATS_PLUGIN_PATH}/load.bash"
+
+  export BUILDKITE_PIPELINE_SLUG=testpipe
+  export BUILDKITE_PLUGIN_SECRETS_PROVIDER="op"
+  export BUILDKITE_PLUGIN_SECRETS_RETRY_BASE_DELAY=0
+  export BUILDKITE_PLUGIN_SECRETS_RETRY_MAX_ATTEMPTS=3
+  export BUILDKITE_PLUGIN_SECRETS_SKIP_REDACTION=true
+  export OP_SERVICE_ACCOUNT_TOKEN="test-token"
+
+  # Create a temp directory for manual mocks
+  TEST_TEMP_DIR=$(mktemp -d)
+
+  # Create a manual buildkite-agent mock that always succeeds
+  cat <<'MOCK' > "$TEST_TEMP_DIR/buildkite-agent"
+#!/bin/bash
+exit 0
+MOCK
+  chmod +x "$TEST_TEMP_DIR/buildkite-agent"
+
+  # Append temp dir to END of PATH so bats-mock stubs take precedence
+  export PATH="$PATH:$TEST_TEMP_DIR"
+}
+
+teardown() {
+  rm -rf "$TEST_TEMP_DIR"
+}
+
+@test "1Password: Fails when op CLI is missing" {
+  local tmp
+  tmp=$(mktemp -d)
+
+  cat <<'EOF' >"$tmp/dirname"
+#!/bin/bash
+/usr/bin/dirname "$@"
+EOF
+  cat <<'EOF' >"$tmp/buildkite-agent"
+#!/bin/bash
+exit 0
+EOF
+  chmod +x "$tmp/dirname" "$tmp/buildkite-agent"
+
+  run env PATH="$tmp" \
+    BUILDKITE_PLUGIN_SECRETS_PROVIDER="op" \
+    OP_SERVICE_ACCOUNT_TOKEN="test-token" \
+    BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="op://vault/item/field" \
+    /bin/bash -c "$PWD/hooks/environment"
+
+  assert_failure
+  assert_output --partial "1Password CLI (op) is required"
+  assert_output --partial "Missing required dependencies: op"
+}
+
+@test "1Password: Fails when no service account token and no active session" {
+  unset OP_SERVICE_ACCOUNT_TOKEN
+
+  stub op \
+    "account list --format=json : exit 1" \
+    "* : exit 1"
+
+  run bash -c "unset OP_SERVICE_ACCOUNT_TOKEN; $PWD/hooks/environment"
+
+  assert_failure
+  assert_output --partial "No 1Password service account token found"
+
+  unstub op || true
+}
+
+@test "1Password: Download single variable" {
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="op://my-vault/my-item/api-key"
+
+  stub op "read op://my-vault/my-item/api-key : echo secret-value-123"
+
+  run bash -c "source $PWD/hooks/environment && echo API_KEY=\$API_KEY"
+
+  assert_success
+  assert_output --partial "API_KEY=secret-value-123"
+  unstub op
+}
+
+@test "1Password: Download multiple variables" {
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="op://vault/item/api-key"
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_DB_PASS="op://vault/item/db-pass"
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_TOKEN="op://vault/item/token"
+
+  stub op \
+    "read op://vault/item/api-key : echo secret-key-123" \
+    "read op://vault/item/db-pass : echo db-pass-456" \
+    "read op://vault/item/token : echo token-789"
+
+  run bash -c "source $PWD/hooks/environment && echo API_KEY=\$API_KEY && echo DB_PASS=\$DB_PASS && echo TOKEN=\$TOKEN"
+
+  assert_success
+  assert_output --partial "API_KEY=secret-key-123"
+  assert_output --partial "DB_PASS=db-pass-456"
+  assert_output --partial "TOKEN=token-789"
+  unstub op
+}
+
+@test "1Password: Download batch env secrets (base64)" {
+  export TESTDATA="Rk9PPWJhcgpTRUNSRVRfS0VZPWxsYW1hcwpDT0ZGRUU9bW9yZQo="
+  export BUILDKITE_PLUGIN_SECRETS_ENV="op://my-vault/batch/env"
+
+  stub op "read op://my-vault/batch/env : echo \${TESTDATA}"
+
+  run bash -c "source $PWD/hooks/environment && echo FOO=\$FOO && echo SECRET_KEY=\$SECRET_KEY && echo COFFEE=\$COFFEE"
+
+  assert_success
+  assert_output --partial "FOO=bar"
+  assert_output --partial "SECRET_KEY=llamas"
+  assert_output --partial "COFFEE=more"
+  unstub op
+}
+
+@test "1Password: No retry on item not found" {
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="op://vault/missing/field"
+
+  stub op "read op://vault/missing/field : echo \"[ERROR] 2024/01/01 00:00:00 isn't an item in the vault\" >&2 && exit 1"
+
+  run bash -c "$PWD/hooks/environment"
+
+  assert_failure
+  refute_output --partial "Retrying"
+  unstub op
+}
+
+@test "1Password: No retry on unauthorized" {
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="op://vault/item/field"
+
+  stub op "read op://vault/item/field : echo '[ERROR] unauthorized' >&2 && exit 1"
+
+  run bash -c "$PWD/hooks/environment"
+
+  assert_failure
+  refute_output --partial "Retrying"
+  unstub op
+}
+
+@test "1Password: Retry on transient error then succeed" {
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="op://vault/item/field"
+
+  stub op \
+    "read op://vault/item/field : echo 'connection error' >&2 && exit 1" \
+    "read op://vault/item/field : echo 'connection error' >&2 && exit 1" \
+    "read op://vault/item/field : echo recovered-value"
+
+  run bash -c "source $PWD/hooks/environment && echo API_KEY=\$API_KEY"
+
+  assert_success
+  assert_output --partial "Failed to fetch secret op://vault/item/field (attempt 1/3)"
+  assert_output --partial "Failed to fetch secret op://vault/item/field (attempt 2/3)"
+  assert_output --partial "API_KEY=recovered-value"
+  unstub op
+}
+
+@test "1Password: Fails after max retry attempts" {
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="op://vault/item/field"
+
+  stub op \
+    "read op://vault/item/field : echo 'Server Error' >&2 && exit 1" \
+    "read op://vault/item/field : echo 'Server Error' >&2 && exit 1" \
+    "read op://vault/item/field : echo 'Server Error' >&2 && exit 1"
+
+  run bash -c "$PWD/hooks/environment"
+
+  assert_failure
+  assert_output --partial "Failed to fetch secret op://vault/item/field after 3 attempts"
+  unstub op
+}
+
+@test "1Password: Rejects invalid secret references" {
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="not-an-op-reference"
+
+  cat <<'MOCK' > "$TEST_TEMP_DIR/op"
+#!/bin/bash
+echo "ERROR: should not be called" >&2
+exit 1
+MOCK
+  chmod +x "$TEST_TEMP_DIR/op"
+
+  run bash -c "$PWD/hooks/environment"
+
+  assert_failure
+  assert_output --partial "Invalid 1Password secret reference"
+}
+
+@test "1Password: Skips invalid variable names in decoded secrets" {
+  export TESTDATA
+  TESTDATA=$(echo -e "VALID=goodvalue\n0INVALID=badvalue\nALSO_VALID=anothervalue" | base64)
+  export BUILDKITE_PLUGIN_SECRETS_ENV="op://vault/batch/env"
+
+  stub op "read op://vault/batch/env : echo \${TESTDATA}"
+
+  run bash -c "source $PWD/hooks/environment && echo VALID=\$VALID && echo ALSO_VALID=\$ALSO_VALID"
+
+  assert_success
+  assert_output --partial "VALID=goodvalue"
+  assert_output --partial "ALSO_VALID=anothervalue"
+  assert_output --partial "Skipping invalid variable name"
+  assert_output --partial "0INVALID"
+  unstub op
+}
+
+@test "1Password: Redacts secrets when enabled" {
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="op://vault/item/api-key"
+  unset BUILDKITE_PLUGIN_SECRETS_SKIP_REDACTION
+
+  stub op "read op://vault/item/api-key : echo secret-value-123"
+
+  stub buildkite-agent \
+    "redactor add --help : echo 'usage info' && exit 0" \
+    "redactor add : cat"
+
+  run bash -c "$PWD/hooks/environment"
+
+  assert_success
+  assert_output --partial "Redacting"
+  assert_output --partial "secret(s)"
+  unstub op
+  unstub buildkite-agent
+}
+
+@test "1Password: Combined env and variables usage" {
+  export TESTDATA
+  TESTDATA=$(echo -e "FOO=bar\nBAR=baz" | base64)
+  export BUILDKITE_PLUGIN_SECRETS_ENV="op://vault/batch/env"
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="op://vault/item/api-key"
+
+  stub op \
+    "read op://vault/batch/env : echo \${TESTDATA}" \
+    "read op://vault/item/api-key : echo individual-secret-value"
+
+  run bash -c "source $PWD/hooks/environment && echo FOO=\$FOO && echo BAR=\$BAR && echo API_KEY=\$API_KEY"
+
+  assert_success
+  assert_output --partial "FOO=bar"
+  assert_output --partial "BAR=baz"
+  assert_output --partial "API_KEY=individual-secret-value"
+  unstub op
+}
+
+@test "1Password: Fails on invalid base64 in env secret" {
+  export BUILDKITE_PLUGIN_SECRETS_ENV="op://vault/batch/env"
+
+  stub op "read op://vault/batch/env : echo '!@#\$%^&*'"
+
+  run bash -c "$PWD/hooks/environment"
+
+  assert_failure
+  assert_output --partial "Failed to decode base64 secret"
+  unstub op
+}
+
+@test "1Password: Fails on whitespace-only decoded env secret" {
+  export WHITESPACE_B64
+  WHITESPACE_B64=$(printf '   \n' | base64)
+  export BUILDKITE_PLUGIN_SECRETS_ENV="op://vault/batch/env"
+
+  stub op "read op://vault/batch/env : echo \${WHITESPACE_B64}"
+
+  run bash -c "$PWD/hooks/environment"
+
+  assert_failure
+  assert_output --partial "empty or contains only whitespace"
+  unstub op
+}

--- a/tests/op-provider.bats
+++ b/tests/op-provider.bats
@@ -186,8 +186,20 @@ EOF
   unstub op
 }
 
+@test "1Password: Accepts short-form reference without op:// prefix" {
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="my-vault/my-item/api-key"
+
+  stub op "read op://my-vault/my-item/api-key : echo secret-value-123"
+
+  run bash -c "source $PWD/hooks/environment && echo API_KEY=\$API_KEY"
+
+  assert_success
+  assert_output --partial "API_KEY=secret-value-123"
+  unstub op
+}
+
 @test "1Password: Rejects invalid secret references" {
-  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="not-an-op-reference"
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="not-enough-parts"
 
   cat <<'MOCK' > "$TEST_TEMP_DIR/op"
 #!/bin/bash

--- a/tests/op-provider.bats
+++ b/tests/op-provider.bats
@@ -53,19 +53,34 @@ EOF
   assert_output --partial "Missing required dependencies: op"
 }
 
-@test "1Password: Fails when no service account token and no active session" {
+@test "1Password: Fails when no auth credentials and no active session" {
   unset OP_SERVICE_ACCOUNT_TOKEN
 
   stub op \
     "account list --format=json : exit 1" \
     "* : exit 1"
 
-  run bash -c "unset OP_SERVICE_ACCOUNT_TOKEN; $PWD/hooks/environment"
+  run bash -c "unset OP_SERVICE_ACCOUNT_TOKEN; unset OP_CONNECT_HOST; unset OP_CONNECT_TOKEN; $PWD/hooks/environment"
 
   assert_failure
-  assert_output --partial "No 1Password service account token found"
+  assert_output --partial "No 1Password authentication found"
 
   unstub op || true
+}
+
+@test "1Password: Succeeds auth check with Connect Server credentials" {
+  unset OP_SERVICE_ACCOUNT_TOKEN
+  export OP_CONNECT_HOST="https://connect.example.com"
+  export OP_CONNECT_TOKEN="test-connect-token"
+  export BUILDKITE_PLUGIN_SECRETS_VARIABLES_API_KEY="op://my-vault/my-item/api-key"
+
+  stub op "read op://my-vault/my-item/api-key : echo connect-secret-value"
+
+  run bash -c "source $PWD/hooks/environment && echo API_KEY=\$API_KEY"
+
+  assert_success
+  assert_output --partial "API_KEY=connect-secret-value"
+  unstub op
 }
 
 @test "1Password: Download single variable" {


### PR DESCRIPTION
## Summary

- Adds a new `op` provider that fetches secrets from 1Password via the `op` CLI
- Secret references use short form `vault/item/field` — the `op://` prefix is added automatically (explicit `op://vault/item/field` also accepted)
- Supports all three auth methods: Connect Server (`OP_CONNECT_HOST` + `OP_CONNECT_TOKEN`), service account (`OP_SERVICE_ACCOUNT_TOKEN`), and interactive `op signin`
- Provider can be set as an agent-level default via `BUILDKITE_PLUGIN_SECRETS_PROVIDER=op` — no pipeline config needed
- Follows the same provider interface as existing GCP/Azure providers (retry with exponential backoff, secret redaction, batch `env` + individual `variables` modes)
- Fixes null byte warnings in base64 redaction logic (affected all providers when secret values decoded to binary data)

## Changes

- `lib/providers/op.bash` — new provider implementation
- `lib/shared.bash` — adds `op` to dependency checking; fixes null byte warnings in base64 redaction by decoding to a temp file and using `tr`/`wc` for portable null byte detection
- `lib/plugin.bash` — registers `op` in setup/fetch dispatch
- `plugin.yml` — adds `op` to provider enum
- `tests/op-provider.bats` — 15 tests covering all behaviours
- `README.md` — documents the new provider

## Usage

```yaml
steps:
  - command: build.sh
    plugins:
      - secrets#v2.1.0:
          provider: op
          variables:
            API_KEY: my-vault/my-item/credential
            DB_PASSWORD: my-vault/db-creds/password
```

Auth is handled via agent environment variables — no additional plugin configuration needed.

## Test plan

- [ ] Run existing test suite via `docker compose run --rm tests`
- [ ] Set `OP_CONNECT_HOST` + `OP_CONNECT_TOKEN` on a Buildkite agent and test with a real pipeline using `provider: op`
- [ ] Verify secrets are redacted from build logs