### PR TITLE
Mute "Fetching secrets" log header by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ These options apply to all providers.
 | `provider` | string | `buildkite` | The secrets provider to use. Supported values: `buildkite`, `gcp`, `azure`. |
 | `env` | string | - | Secret key name for fetching batch secrets (base64-encoded `KEY=value` format). |
 | `variables` | object | - | Map of `ENV_VAR_NAME: secret-path` pairs to inject as environment variables. |
+| `mute-log` | boolean | `true` | If `true` (default), the "Fetching secrets" header renders as a de-emphasized `~~~` group. Set to `false` to use the bold `---` style. |
 | `skip-redaction` | boolean | `false` | If `true`, secrets will not be automatically redacted from logs. |
 | `retry-max-attempts` | number | `5` | Maximum retry attempts for transient failures. |
 | `retry-base-delay` | number | `2` | Base delay in seconds for exponential backoff between retries. |

--- a/hooks/environment
+++ b/hooks/environment
@@ -14,7 +14,11 @@ else
 fi
 
 main() {
-  echo "--- :closed_lock_with_key: Fetching secrets"
+  local log_prefix="~~~"
+  if [[ "${BUILDKITE_PLUGIN_SECRETS_MUTE_LOG:-true}" == "false" ]]; then
+    log_prefix="---"
+  fi
+  echo "${log_prefix} :closed_lock_with_key: Fetching secrets"
 
   log_info "Using secrets provider ${BUILDKITE_PLUGIN_SECRETS_PROVIDER}"
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -24,6 +24,10 @@ configuration:
     variables:
       type: object
       description: "Map of ENV_VAR_NAME: secret-path for individual secrets"
+    mute-log:
+      type: boolean
+      default: true
+      description: "If true (default), the 'Fetching secrets' log header uses '~~~' (de-emphasized). Set to false to use '---' (bold)."
     skip-redaction:
       type: boolean
       default: false

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -10,6 +10,35 @@ setup() {
   export BUILDKITE_PLUGIN_SECRETS_SKIP_REDACTION=true
 }
 
+@test "Uses muted header (~~~) by default" {
+    export TESTDATA='Rk9PPWJhcgpCQVI9QmF6ClNFQ1JFVD1sbGFtYXMK'
+    export BUILDKITE_PLUGIN_SECRETS_ENV="env"
+
+    stub buildkite-agent "secret get env : echo ${TESTDATA}"
+
+    run bash -c "$PWD/hooks/environment"
+
+    assert_success
+    assert_output --partial "~~~ :closed_lock_with_key: Fetching secrets"
+    refute_output --partial "--- :closed_lock_with_key: Fetching secrets"
+    unstub buildkite-agent
+}
+
+@test "Uses bold header (---) when mute-log is false" {
+    export TESTDATA='Rk9PPWJhcgpCQVI9QmF6ClNFQ1JFVD1sbGFtYXMK'
+    export BUILDKITE_PLUGIN_SECRETS_ENV="env"
+    export BUILDKITE_PLUGIN_SECRETS_MUTE_LOG=false
+
+    stub buildkite-agent "secret get env : echo ${TESTDATA}"
+
+    run bash -c "$PWD/hooks/environment"
+
+    assert_success
+    assert_output --partial "--- :closed_lock_with_key: Fetching secrets"
+    refute_output --partial "~~~ :closed_lock_with_key: Fetching secrets"
+    unstub buildkite-agent
+}
+
 @test "Fails when buildkite-agent is missing" {
     local tmp
     tmp=$(mktemp -d)


### PR DESCRIPTION
Switches the group prefix from --- to ~~~ so the header renders as a de-emphasized, non-bold group in Buildkite logs. Users who prefer the original bold style can opt out with `mute-log: false`.