### PR TITLE
Add `phases` option to scope secret fetching on Agent Stack for Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,32 @@ both the checkout container and the command container in this case. Each one fet
 By default, the Buildkite Agent ships with `git` and `ssh` which are required for this plugin,if you are using a custom image, please ensure that `git`, `ssh` and if your token is base64 encoded, `base64`
 are installed.
 
+#### Limiting a plugin instance to specific phases
+
+Because the environment hook re-runs once per container, secrets that are only needed by your
+`command` step (e.g. `variables`, `env`, `json-variables`) get fetched a second time, unused, in
+the `checkout` container. Use `phases` to scope a plugin instance to the container(s) it's
+actually needed in:
+
+```yaml
+steps:
+  - command: build.sh
+    plugins:
+      - secrets#v2.4.0:
+          provider: aws
+          phases: [command]
+          variables:
+            API_KEY: my-api-key-secret
+      - secrets#v2.4.0:
+          provider: gcp
+          phases: [checkout]
+          git-credentials: github-https-credentials
+```
+
+`phases` defaults to `[checkout, command]`, matching the plugin's current behaviour. It's only
+meaningful on Agent Stack for Kubernetes: classic agents run the environment hook once for the
+whole job, so there's nothing to gate there and the option is ignored.
+
 ## Options
 
 ### Common Options
@@ -662,6 +688,7 @@ These options apply to all providers.
 | `env` | string | - | Secret key name for fetching batch secrets (base64-encoded `KEY=value` format). |
 | `variables` | object | - | Map of `ENV_VAR_NAME: secret-path` pairs to inject as environment variables. |
 | `json-variables` | array | - | List of `{ secret-id, json-key }` objects (AWS only). Expands the JSON object at `json-key` (a jq path, default `.`) within each secret into one environment variable per key. |
+| `phases` | array | `[checkout, command]` | Which job phases this plugin instance applies to. Only relevant on [Agent Stack for Kubernetes](#agent-stack-for-kubernetes), where the environment hook re-runs once per phase container. |
 | `mute-log` | boolean | `true` | If `true` (default), the "Fetching secrets" header renders as a de-emphasized `~~~` group. Set to `false` to use the bold `---` style. |
 | `skip-redaction` | boolean | `false` | If `true`, secrets will not be automatically redacted from logs. |
 | `retry-max-attempts` | number | `5` | Maximum retry attempts for transient failures. |

--- a/hooks/environment
+++ b/hooks/environment
@@ -14,6 +14,11 @@ else
 fi
 
 main() {
+  if ! phase_applies_to_current_container; then
+    log_info "Skipping secret fetch: current phase (BUILDKITE_BOOTSTRAP_PHASES=${BUILDKITE_BOOTSTRAP_PHASES:-}) is not in the configured phases"
+    return 0
+  fi
+
   local log_prefix="~~~"
   if [[ "${BUILDKITE_PLUGIN_SECRETS_MUTE_LOG:-true}" == "false" ]]; then
     log_prefix="---"

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -25,6 +25,16 @@ plugin_read_config() {
     fi
   done
 
+  # Export phases array (which job phases this plugin instance applies to)
+  for ((i=0; ; i++)); do
+    local phase_var="BUILDKITE_PLUGIN_SECRETS_PHASES_$i"
+    if [[ -n "${!phase_var:-}" ]]; then
+      export "BUILDKITE_PLUGIN_SECRETS_PHASES_$i"
+    else
+      break
+    fi
+  done
+
   # Export json-variables array of { secret-id, json-key } objects
   # (AWS provider: expand a secret's JSON content into env vars, one per key)
   for ((i=0; ; i++)); do

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -312,10 +312,19 @@ phase_applies_to_current_container() {
   fi
 
   local configured_phases=()
+  local i var_name phase
   for ((i=0; ; i++)); do
-    local var_name="BUILDKITE_PLUGIN_SECRETS_PHASES_$i"
+    var_name="BUILDKITE_PLUGIN_SECRETS_PHASES_$i"
     if [[ -n "${!var_name:-}" ]]; then
-      configured_phases+=("${!var_name}")
+      phase="${!var_name}"
+      case "$phase" in
+        checkout|command) ;;
+        *)
+          log_error "Invalid phases value '${phase}': must be 'checkout' or 'command'"
+          exit 1
+          ;;
+      esac
+      configured_phases+=("$phase")
     else
       break
     fi
@@ -326,7 +335,6 @@ phase_applies_to_current_container() {
     configured_phases=("checkout" "command")
   fi
 
-  local phase
   for phase in "${configured_phases[@]}"; do
     if [[ "$bootstrap_phases" == *"$phase"* ]]; then
       return 0

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -299,6 +299,43 @@ decode_if_base64() {
   if [[ $xtrace_was_set -eq 1 ]]; then set -x; fi
 }
 
+# On Agent Stack for Kubernetes, the environment hook runs once per phase
+# container, and BUILDKITE_BOOTSTRAP_PHASES lists the phase(s) that
+# container is executing (e.g. contains "checkout" or "command"). Classic
+# agents run the environment hook exactly once for the whole job and never
+# set this variable, so there's nothing to gate there.
+phase_applies_to_current_container() {
+  local bootstrap_phases="${BUILDKITE_BOOTSTRAP_PHASES:-}"
+
+  if [[ -z "$bootstrap_phases" ]]; then
+    return 0
+  fi
+
+  local configured_phases=()
+  for ((i=0; ; i++)); do
+    local var_name="BUILDKITE_PLUGIN_SECRETS_PHASES_$i"
+    if [[ -n "${!var_name:-}" ]]; then
+      configured_phases+=("${!var_name}")
+    else
+      break
+    fi
+  done
+
+  # Default to both phases when unset, preserving current behavior
+  if [[ ${#configured_phases[@]} -eq 0 ]]; then
+    configured_phases=("checkout" "command")
+  fi
+
+  local phase
+  for phase in "${configured_phases[@]}"; do
+    if [[ "$bootstrap_phases" == *"$phase"* ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 validate_git_auth_config() {
   if [[ -n "${BUILDKITE_PLUGIN_SECRETS_GIT_CREDENTIALS:-}" && -n "${BUILDKITE_PLUGIN_SECRETS_GIT_SSH_KEY:-}" ]]; then
     log_error "git-credentials and git-ssh-key are mutually exclusive. Configure one git auth method per step."

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -335,6 +335,11 @@ phase_applies_to_current_container() {
     configured_phases=("checkout" "command")
   fi
 
+  # Substring match is safe because the case statement above restricts
+  # configured_phases to exactly "checkout" or "command", and Buildkite's
+  # phase names in BUILDKITE_BOOTSTRAP_PHASES don't overlap with each other.
+  # If a future phase (e.g. "pre-checkout") is ever added to the enum,
+  # switch this to an exact/word-boundary match instead.
   for phase in "${configured_phases[@]}"; do
     if [[ "$bootstrap_phases" == *"$phase"* ]]; then
       return 0

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -301,13 +301,19 @@ decode_if_base64() {
 
 # On Agent Stack for Kubernetes, the environment hook runs once per phase
 # container, and BUILDKITE_BOOTSTRAP_PHASES lists the phase(s) that
-# container is executing (e.g. contains "checkout" or "command"). Classic
-# agents run the environment hook exactly once for the whole job and never
-# set this variable, so there's nothing to gate there.
+# container is executing (e.g. contains "checkout" or "command").
+#
+# BUILDKITE_BOOTSTRAP_PHASES alone isn't a reliable signal for "we're on
+# Agent Stack for Kubernetes": classic agents support it too (e.g. to
+# restrict which phases a bootstrap invocation runs), so gating on it there
+# would silently skip secret fetches on a single-container job. Require
+# BUILDKITE_CONTAINER_ID as well, since the agent defines that variable as
+# specific to Agent Stack for Kubernetes.
 phase_applies_to_current_container() {
   local bootstrap_phases="${BUILDKITE_BOOTSTRAP_PHASES:-}"
+  local container_id="${BUILDKITE_CONTAINER_ID:-}"
 
-  if [[ -z "$bootstrap_phases" ]]; then
+  if [[ -z "$bootstrap_phases" || -z "$container_id" ]]; then
     return 0
   fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -45,8 +45,8 @@ configuration:
       items:
         type: string
         enum: ["checkout", "command"]
-        enum: ["checkout", "command"]
       minItems: 1
+      default: ["checkout", "command"]
       description: "Which job phases this plugin instance applies to. Only relevant on Agent Stack for Kubernetes, where the environment hook re-runs once per phase container; classic agents run it once for the whole job regardless of this setting. Defaults to both phases (current behavior)."
     mute-log:
       type: boolean

--- a/plugin.yml
+++ b/plugin.yml
@@ -40,6 +40,13 @@ configuration:
         required:
           - secret-id
         additionalProperties: false
+    phases:
+      type: array
+      items:
+        type: string
+        enum: ["checkout", "command"]
+      default: ["checkout", "command"]
+      description: "Which job phases this plugin instance applies to. Only relevant on Agent Stack for Kubernetes, where the environment hook re-runs once per phase container; classic agents run it once for the whole job regardless of this setting. Defaults to both phases (current behavior)."
     mute-log:
       type: boolean
       default: true

--- a/plugin.yml
+++ b/plugin.yml
@@ -45,7 +45,8 @@ configuration:
       items:
         type: string
         enum: ["checkout", "command"]
-      default: ["checkout", "command"]
+        enum: ["checkout", "command"]
+      minItems: 1
       description: "Which job phases this plugin instance applies to. Only relevant on Agent Stack for Kubernetes, where the environment hook re-runs once per phase container; classic agents run it once for the whole job regardless of this setting. Defaults to both phases (current behavior)."
     mute-log:
       type: boolean

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -313,6 +313,17 @@ EOF
     unstub buildkite-agent
 }
 
+@test "Fails with a clear error on an invalid phases value" {
+    export BUILDKITE_PLUGIN_SECRETS_ENV="env"
+    export BUILDKITE_PLUGIN_SECRETS_PHASES_0="chekout"
+    export BUILDKITE_BOOTSTRAP_PHASES="plugin,environment,checkout"
+
+    run bash -c "$PWD/hooks/environment"
+
+    assert_failure
+    assert_output --partial "Invalid phases value 'chekout'"
+}
+
 @test "Fetches in both containers by default when phases is unset" {
     export TESTDATA='Rk9PPWJhcgpCQVI9QmF6ClNFQ1JFVD1sbGFtYXMK'
     export BUILDKITE_PLUGIN_SECRETS_ENV="env"

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -313,6 +313,18 @@ EOF
     unstub buildkite-agent
 }
 
+@test "Skips fetching in command container when phases is checkout-only" {
+    export BUILDKITE_PLUGIN_SECRETS_ENV="env"
+    export BUILDKITE_PLUGIN_SECRETS_PHASES_0="checkout"
+    export BUILDKITE_BOOTSTRAP_PHASES="plugin,environment,command"
+
+    run bash -c "$PWD/hooks/environment"
+
+    assert_success
+    assert_output --partial "Skipping secret fetch"
+    refute_output --partial ":closed_lock_with_key: Fetching secrets"
+}
+
 @test "Fails with a clear error on an invalid phases value" {
     export BUILDKITE_PLUGIN_SECRETS_ENV="env"
     export BUILDKITE_PLUGIN_SECRETS_PHASES_0="chekout"

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -271,6 +271,62 @@ EOF
     unstub buildkite-agent
 }
 
+@test "Runs on classic agents regardless of phases config (BUILDKITE_BOOTSTRAP_PHASES unset)" {
+    export TESTDATA='Rk9PPWJhcgpCQVI9QmF6ClNFQ1JFVD1sbGFtYXMK'
+    export BUILDKITE_PLUGIN_SECRETS_ENV="env"
+    export BUILDKITE_PLUGIN_SECRETS_PHASES_0="command"
+    unset BUILDKITE_BOOTSTRAP_PHASES
+
+    stub buildkite-agent "secret get env : echo ${TESTDATA}"
+
+    run bash -c "$PWD/hooks/environment"
+
+    assert_success
+    assert_output --partial ":closed_lock_with_key: Fetching secrets"
+    unstub buildkite-agent
+}
+
+@test "Skips fetching in the checkout container when phases is command-only" {
+    export BUILDKITE_PLUGIN_SECRETS_ENV="env"
+    export BUILDKITE_PLUGIN_SECRETS_PHASES_0="command"
+    export BUILDKITE_BOOTSTRAP_PHASES="plugin,environment,checkout"
+
+    run bash -c "$PWD/hooks/environment"
+
+    assert_success
+    assert_output --partial "Skipping secret fetch"
+    refute_output --partial ":closed_lock_with_key: Fetching secrets"
+}
+
+@test "Fetches in the command container when phases is command-only" {
+    export TESTDATA='Rk9PPWJhcgpCQVI9QmF6ClNFQ1JFVD1sbGFtYXMK'
+    export BUILDKITE_PLUGIN_SECRETS_ENV="env"
+    export BUILDKITE_PLUGIN_SECRETS_PHASES_0="command"
+    export BUILDKITE_BOOTSTRAP_PHASES="plugin,environment,command"
+
+    stub buildkite-agent "secret get env : echo ${TESTDATA}"
+
+    run bash -c "$PWD/hooks/environment"
+
+    assert_success
+    assert_output --partial ":closed_lock_with_key: Fetching secrets"
+    unstub buildkite-agent
+}
+
+@test "Fetches in both containers by default when phases is unset" {
+    export TESTDATA='Rk9PPWJhcgpCQVI9QmF6ClNFQ1JFVD1sbGFtYXMK'
+    export BUILDKITE_PLUGIN_SECRETS_ENV="env"
+    export BUILDKITE_BOOTSTRAP_PHASES="plugin,environment,checkout"
+
+    stub buildkite-agent "secret get env : echo ${TESTDATA}"
+
+    run bash -c "$PWD/hooks/environment"
+
+    assert_success
+    assert_output --partial ":closed_lock_with_key: Fetching secrets"
+    unstub buildkite-agent
+}
+
 @test "Skip invalid variable names in decoded secrets" {
     # Create secret with invalid variable name (starts with number)
     export TESTDATA=$(echo -e "VALID=goodvalue\n0INVALID=badvalue\nALSO_VALID=anothervalue" | base64)

--- a/tests/environment-hook.bats
+++ b/tests/environment-hook.bats
@@ -8,6 +8,8 @@ setup() {
   export BUILDKITE_PIPELINE_SLUG=testpipe
   export BUILDKITE_PLUGIN_SECRETS_RETRY_BASE_DELAY=0
   export BUILDKITE_PLUGIN_SECRETS_SKIP_REDACTION=true
+  unset BUILDKITE_BOOTSTRAP_PHASES
+  unset BUILDKITE_CONTAINER_ID
 }
 
 @test "Uses muted header (~~~) by default" {
@@ -290,6 +292,7 @@ EOF
     export BUILDKITE_PLUGIN_SECRETS_ENV="env"
     export BUILDKITE_PLUGIN_SECRETS_PHASES_0="command"
     export BUILDKITE_BOOTSTRAP_PHASES="plugin,environment,checkout"
+    export BUILDKITE_CONTAINER_ID="0"
 
     run bash -c "$PWD/hooks/environment"
 
@@ -303,6 +306,7 @@ EOF
     export BUILDKITE_PLUGIN_SECRETS_ENV="env"
     export BUILDKITE_PLUGIN_SECRETS_PHASES_0="command"
     export BUILDKITE_BOOTSTRAP_PHASES="plugin,environment,command"
+    export BUILDKITE_CONTAINER_ID="1"
 
     stub buildkite-agent "secret get env : echo ${TESTDATA}"
 
@@ -317,6 +321,7 @@ EOF
     export BUILDKITE_PLUGIN_SECRETS_ENV="env"
     export BUILDKITE_PLUGIN_SECRETS_PHASES_0="checkout"
     export BUILDKITE_BOOTSTRAP_PHASES="plugin,environment,command"
+    export BUILDKITE_CONTAINER_ID="1"
 
     run bash -c "$PWD/hooks/environment"
 
@@ -329,6 +334,7 @@ EOF
     export BUILDKITE_PLUGIN_SECRETS_ENV="env"
     export BUILDKITE_PLUGIN_SECRETS_PHASES_0="chekout"
     export BUILDKITE_BOOTSTRAP_PHASES="plugin,environment,checkout"
+    export BUILDKITE_CONTAINER_ID="0"
 
     run bash -c "$PWD/hooks/environment"
 
@@ -340,6 +346,23 @@ EOF
     export TESTDATA='Rk9PPWJhcgpCQVI9QmF6ClNFQ1JFVD1sbGFtYXMK'
     export BUILDKITE_PLUGIN_SECRETS_ENV="env"
     export BUILDKITE_BOOTSTRAP_PHASES="plugin,environment,checkout"
+    export BUILDKITE_CONTAINER_ID="0"
+
+    stub buildkite-agent "secret get env : echo ${TESTDATA}"
+
+    run bash -c "$PWD/hooks/environment"
+
+    assert_success
+    assert_output --partial ":closed_lock_with_key: Fetching secrets"
+    unstub buildkite-agent
+}
+
+@test "Runs on a classic agent even if BUILDKITE_BOOTSTRAP_PHASES is set without BUILDKITE_CONTAINER_ID" {
+    export TESTDATA='Rk9PPWJhcgpCQVI9QmF6ClNFQ1JFVD1sbGFtYXMK'
+    export BUILDKITE_PLUGIN_SECRETS_ENV="env"
+    export BUILDKITE_PLUGIN_SECRETS_PHASES_0="command"
+    export BUILDKITE_BOOTSTRAP_PHASES="plugin,checkout"
+    unset BUILDKITE_CONTAINER_ID
 
     stub buildkite-agent "secret get env : echo ${TESTDATA}"
 


### PR DESCRIPTION
Adds a phases option (checkout / command, default both) to scope a plugin instance to specific job phases.
On Agent Stack for Kubernetes, the environment hook re-runs once per container, so command-only secrets (variables, json-variables, env) were also being fetched, unused, in the checkout container. phases: [command] skips the fetch there entirely