### PR TITLE
Update README version for v2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A `pipeline.yml` like this will read each secret out into an environment variabl
 steps:
   - command: echo "The content of ANIMAL is \$ANIMAL"
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           variables:
             ANIMAL: llamas
             FOO: bar
@@ -66,7 +66,7 @@ job environment using a pipeline.yml like this:
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           env: "llamas"
 ```
 
@@ -99,7 +99,7 @@ steps:
       - gcp-workload-identity-federation#v1.5.0:
           audience: "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/buildkite"
           service-account: "my-service-account@my-project-id.iam.gserviceaccount.com"
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: gcp
           gcp-project: my-project-id
           variables:
@@ -134,7 +134,7 @@ steps:
       - gcp-workload-identity-federation#v1.5.0:
           audience: "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/buildkite"
           service-account: "my-service-account@my-project-id.iam.gserviceaccount.com"
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: gcp
           gcp-project: my-project-id
           env: "ci-env-secrets"
@@ -161,7 +161,7 @@ steps:
       - azure-login#v1.0.1:
           client-id: "your-client-id"
           tenant-id: "your-tenant-id"
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: azure
           azure-vault-name: my-vault
           variables:
@@ -179,7 +179,7 @@ steps:
       - azure-login#v1.0.1:
           client-id: "your-client-id"
           tenant-id: "your-tenant-id"
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: azure
           azure-vault-name: my-vault
           variables:
@@ -201,7 +201,7 @@ steps:
       - azure-login#v1.0.1:
           client-id: "your-client-id"
           tenant-id: "your-tenant-id"
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: azure
           azure-vault-name: my-vault
           env: batch-secrets
@@ -246,7 +246,7 @@ Create secrets in AWS Secrets Manager, then map them to environment variables:
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: aws
           aws-region: us-east-1
           variables:
@@ -278,7 +278,7 @@ Then reference the secret in your pipeline:
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: aws
           aws-region: us-east-1
           env: "ci-env-secrets"
@@ -292,7 +292,7 @@ AWS Secrets Manager commonly stores secrets as a single JSON object (e.g. `{"use
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: aws
           aws-region: us-east-1
           json-variables:
@@ -320,7 +320,7 @@ Each entry takes:
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: aws
           aws-region: us-east-1
           json-variables:
@@ -375,7 +375,7 @@ Map environment variable names to secret references:
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: op
           variables:
             API_KEY: my-vault/my-api-key/credential
@@ -405,7 +405,7 @@ Then reference it in your pipeline:
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: op
           env: my-vault/ci-batch-secrets/credential
 ```
@@ -423,7 +423,7 @@ steps:
       - gcp-workload-identity-federation#v1.5.0:
           audience: "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/buildkite"
           service-account: "my-service-account@my-project-id.iam.gserviceaccount.com"
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: gcp
           gcp-project: my-project-id
           env: "ci-env-secrets"
@@ -440,7 +440,7 @@ steps:
       - azure-login#v1.0.1:
           client-id: "your-client-id"
           tenant-id: "your-tenant-id"
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: azure
           azure-vault-name: my-vault
           env: batch-secrets
@@ -454,7 +454,7 @@ steps:
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: aws
           aws-region: us-east-1
           env: "ci-env-secrets"
@@ -470,7 +470,7 @@ steps:
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: op
           env: my-vault/ci-batch-secrets/credential
           variables:
@@ -488,7 +488,7 @@ steps:
       - gcp-workload-identity-federation#v1.5.0:
           audience: "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/my-pool/providers/buildkite"
           service-account: "my-service-account@my-project-id.iam.gserviceaccount.com"
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: gcp
           gcp-project: my-project-id
           gcp-secret-version: "5"
@@ -507,7 +507,7 @@ steps:
       - azure-login#v1.0.1:
           client-id: "your-client-id"
           tenant-id: "your-tenant-id"
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: azure
           azure-vault-name: my-vault
           azure-secret-version: "a1b2c3d4e5f6"
@@ -523,7 +523,7 @@ By default, the `AWSCURRENT` staged version of each secret is fetched. To pin to
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: aws
           aws-region: us-east-1
           aws-secret-version-id: "EXAMPLE1-90ab-cdef-fedc-ba987EXAMPLE"
@@ -537,7 +537,7 @@ Or pin to a staging label (e.g. `AWSPREVIOUS`) with `aws-secret-version-stage`:
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: aws
           aws-region: us-east-1
           aws-secret-version-stage: "AWSPREVIOUS"
@@ -561,7 +561,7 @@ plugin configures git's store credential helper to use it:
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: gcp
           gcp-project: my-project-id
           git-credentials: github-https-credentials
@@ -596,7 +596,7 @@ to ensure that tokens are used per-job, opposed to agent-wide.
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: gcp
           gcp-project: my-project-id
           git-ssh-key: deploy-key
@@ -607,7 +607,7 @@ different host such as a self-hosted git server, supply your own
 `known_hosts` contents:
 
 ```yaml
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: gcp
           gcp-project: my-project-id
           git-ssh-key: deploy-key
@@ -661,12 +661,12 @@ actually needed in:
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: aws
           phases: [command]
           variables:
             API_KEY: my-api-key-secret
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           provider: gcp
           phases: [checkout]
           git-credentials: github-https-credentials
@@ -746,7 +746,7 @@ To disable automatic redaction (not recommended), set `skip-redaction: true`:
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           env: "llamas"
           skip-redaction: true
 ```
@@ -763,7 +763,7 @@ By default, the base delay will be 2 seconds, with a maximum of 5 retries.
 steps:
   - command: build.sh
     plugins:
-      - secrets#v2.4.0:
+      - secrets#v2.5.0:
           env: "llamas"
           retry-max-attempts: 10
           retry-base-delay: 2


### PR DESCRIPTION
Bumps README version references from v2.4.0 to v2.5.0 ahead of the v2.5.0 release, which adds the `phases` option for scoping secret fetches on Agent Stack for Kubernetes (From PR 22).
